### PR TITLE
bumping jupyterLab version, and adding git interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN python3 -m ensurepip
 
 RUN pip3 install --upgrade pip setuptools wheel pycurl
 
+RUN pip3 install --upgrade jupyterlab-git
+
 ADD requirements.txt /srv/jupyterhub/
 RUN pip3 install \
     --trusted-host pypi.org \
@@ -17,9 +19,9 @@ RUN pip3 install \
 
 ADD https://raw.githubusercontent.com/jupyterhub/jupyterhub/master/examples/cull-idle/cull_idle_servers.py /usr/local/share/jupyterhub/
 
-RUN jupyter lab build \
+RUN jupyter lab build --minimize=False \
     && jupyter nbextension enable --py --sys-prefix widgetsnbextension \
-    && jupyter labextension install @jupyter-widgets/jupyterlab-manager
+    && jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0
 
 WORKDIR /usr/lib/python3.8/site-packages/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jupyterlab==1.2.11
+jupyterlab==2.1.4
 oauthenticator==0.11.0
 pypandoc==1.5
 pyspark==2.4.5


### PR DESCRIPTION
Adding Git integration in JupyterLab. Had to remove `minimize` option to allow container build and bump the JupyterLab version to be compatible with Git plugin. Bumped `jupyterlab-manager` version as well for the same reason. 