### PR TITLE
Adding an alert to Slack on failure to publish to Docker

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -59,6 +59,16 @@ jobs:
           tags: "latest, ${{ needs.get-publish-version.outputs.publish-version }}"
           tag_semver: true
 
+      - name: notify-slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,commit,author,workflow
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: ${{ failure() }}
+
   snyk-monitor:
     runs-on: ubuntu-latest
     needs: publish-docker


### PR DESCRIPTION
* Adding step in `publish-docker` job to push alert to Slack channel on failure on master 