### PR TITLE
[DW-4658] Add gitclone and git config options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,11 @@ RUN apk del alpine-sdk g++ gcc krb5-dev libffi-dev npm pkgconfig python3-dev
 ADD entrypoint.sh /
 RUN chmod +x /entrypoint.sh
 
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
+
 EXPOSE 8000
 
 HEALTHCHECK --interval=12s --timeout=12s --start-period=20s \  

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,5 +19,17 @@ mkdir /git
 chown "${USER}:${USER}" /git
 chmod 755 /git
 
+cd /git
+git clone "codecommit::eu-west-2://${GIT_REPO}"
+cd ${GIT_REPO}
+
+# Tells git branch, git switch and git checkout to set up new branches so that git-pull will
+# appropriately merge from the starting point branch.
+git config branch.autoSetupMerge always
+
+# When pushing, don't ask for upstream branch - just push to the remote branch with the same name.
+# Creates remote branch if it doesn't exist
+git config push.default current
+
 /usr/sbin/crond -f -l 8 &
 jupyterhub $@


### PR DESCRIPTION
* Install AWS Cli to allow for codecommit git clone
* Set git config options to allow for Jupyterhub to push/pull new branches
* Clone the git repo (from ENV Vars) on startup

NOTE - the gitconfig options won't take effect until https://github.com/jupyterlab/jupyterlab-git/pull/412 is merged and we rebuild Jupyterhub docker image with latests jupyterlab release