### PR TITLE
DW-5040: Re-enable terminal in JupyterHub

### DIFF
--- a/jupyter_local_conf.py
+++ b/jupyter_local_conf.py
@@ -11,7 +11,7 @@ username = getpass.getuser()
 
 c = get_config()
 
-c.NotebookApp.terminals_enabled = False
+c.NotebookApp.terminals_enabled = True
 
 c.NotebookApp.contents_manager_class = HybridContentsManager
 


### PR DESCRIPTION
Re-enable now that we have terminal logging.